### PR TITLE
Speed up for large files & ssh-agent support

### DIFF
--- a/modules/Backends/sftp.js
+++ b/modules/Backends/sftp.js
@@ -128,7 +128,11 @@ exports.SSHConnection.prototype.connectUsingCredentials = function(){
 		}
 		else{
 			var privateKeyPath = path.resolve(getUserHome(),'.ssh/id_rsa');
-			if(fs.existsSync(privateKeyPath)){
+			// assume ssh-agent is running when the environment variable containing the socket is set
+			if(process.env["SSH_AUTH_SOCK"] != undefined){
+				return this.connect({host : host, username : user, agent : process.env["SSH_AUTH_SOCK"], port : 22});
+			}
+			else if(fs.existsSync(privateKeyPath)){
 				return this.connect({host : host,username : user, privateKey : fs.readFileSync(privateKeyPath), port : 22});
 			}
 			else{


### PR DESCRIPTION
We ran into some issues with very large files, where a git diff took 4 minutes on a 200MB file. Turns out the problem was frequent reallocations as the data was piped through git. Switching to larger buffers fixed that, we're now at 7 seconds for the same file.

The other feature is adding support for using ssh-agent instead of going to the key files directly. The main advantage is that you can use keys with passphrases, which you can't do otherwise.
