### PR TITLE
Added support for pageant, ssh authentication agent on Windows.

### DIFF
--- a/modules/Backends/sftp.js
+++ b/modules/Backends/sftp.js
@@ -135,6 +135,10 @@ exports.SSHConnection.prototype.connectUsingCredentials = function(){
 			else if(fs.existsSync(privateKeyPath)){
 				return this.connect({host : host,username : user, privateKey : fs.readFileSync(privateKeyPath), port : 22});
 			}
+			else if(process.platform === 'win32') {
+				//If private key was not provided and we are on Windows, try pageant.
+				return this.connect({host : host, username : user, agent : 'pageant', port : 22});
+			}
 			else{
 				throw new Error('Please set up a password for SFTP connection :\n\tgit jam config sftp.password <pswd>\nYou can also set up a SSH key pair in HOME/.ssh.');
 			}


### PR DESCRIPTION
git-jam will default to try to connect using pageant if
process.platform is 'win32', SSH_AUTH_SOCK is not specified and
private key cannot be found in ~/.ssh/id_rsa.

For better support it should probably be configurable, because
with this change, trying to connect without password and not
configured keys will result in "Authentication failure." error
from ssh instead of "Please set up as password..." error from
git-jam.
